### PR TITLE
fix: migrate to Astro v6 Content Layer API

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,7 +1,8 @@
 import { defineCollection, z } from "astro:content";
+import { glob } from "astro/loaders";
 
 const posts = defineCollection({
-  type: "content",
+  loader: glob({ pattern: "**/*.{md,mdx}", base: "./src/content/posts" }),
   schema: z.object({
     title: z.string(),
     description: z.string().optional(),
@@ -13,4 +14,3 @@ const posts = defineCollection({
 });
 
 export const collections = { posts };
-

--- a/src/pages/[year]/[month]/[day]/[slug]/index.astro
+++ b/src/pages/[year]/[month]/[day]/[slug]/index.astro
@@ -1,31 +1,32 @@
 ---
-import { getCollection } from "astro:content";
+import { getCollection, render } from "astro:content";
 import BaseLayout from "../../../../../layouts/BaseLayout.astro";
 import ThemeToggle from "../../../../../components/ThemeToggle.astro";
 import { formatPostDate, getYmdParts } from "../../../../../utils/dates";
-import { getPostUrl, sortPostsDesc } from "../../../../../utils/posts";
+import { getPostSlug, getPostUrl, sortPostsDesc } from "../../../../../utils/posts";
 import { withBase } from "../../../../../utils/urls";
 
 export async function getStaticPaths() {
   const posts = sortPostsDesc(await getCollection("posts"));
   return posts.map((post) => {
     const { year, month, day } = getYmdParts(post.data.pubDate);
+    const slug = getPostSlug(post);
     return {
-      params: { year, month, day, slug: post.slug },
-      props: { slug: post.slug },
+      params: { year, month, day, slug },
+      props: { slug },
     };
   });
 }
 
 const posts = sortPostsDesc(await getCollection("posts"));
-const current = posts.find((p) => p.slug === Astro.props.slug);
+const current = posts.find((p) => getPostSlug(p) === Astro.props.slug);
 if (!current) throw new Error(`Post not found: ${Astro.props.slug}`);
 
-const index = posts.findIndex((p) => p.slug === current.slug);
+const index = posts.findIndex((p) => getPostSlug(p) === getPostSlug(current));
 const previous = index < posts.length - 1 ? posts[index + 1] : null; // older (previous post by date)
 const next = index > 0 ? posts[index - 1] : null; // newer (next post by date)
 
-const { Content } = await current.render();
+const { Content } = await render(current);
 ---
 
 <BaseLayout title={current.data.title} description={current.data.description}>

--- a/src/pages/llms-full.txt.ts
+++ b/src/pages/llms-full.txt.ts
@@ -14,7 +14,9 @@ export const GET: APIRoute = async () => {
     parts.push("");
     parts.push(`# ${post.data.title}`);
     parts.push("");
-    parts.push(post.body.trim());
+    if (post.body) {
+      parts.push(post.body.trim());
+    }
     parts.push("");
     parts.push("--- END OF POST ---");
   }

--- a/src/utils/posts.ts
+++ b/src/utils/posts.ts
@@ -9,9 +9,16 @@ const slugCollator = new Intl.Collator(undefined, {
   sensitivity: "base",
 });
 
+/**
+ * Get the slug from a post entry (id without extension)
+ */
+export function getPostSlug(post: PostEntry): string {
+  return post.id.replace(/\.(md|mdx)$/, "");
+}
+
 export function getPostPath(post: PostEntry): string {
   const { year, month, day } = getYmdParts(post.data.pubDate);
-  return `/${year}/${month}/${day}/${post.slug}/`;
+  return `/${year}/${month}/${day}/${getPostSlug(post)}/`;
 }
 
 export function getPostUrl(post: PostEntry): string {
@@ -24,6 +31,6 @@ export function sortPostsDesc(posts: PostEntry[]): PostEntry[] {
     if (byDate !== 0) return byDate;
 
     // Stable tie-break: newer-ish slugs first (e.g. "-2" before "-1")
-    return slugCollator.compare(b.slug, a.slug);
+    return slugCollator.compare(getPostSlug(b), getPostSlug(a));
   });
 }


### PR DESCRIPTION
- Move content config from src/content/config.ts to src/content.config.ts
- Add glob loader to posts collection as required by Astro v6
- Replace post.slug with getPostSlug(post) helper (uses post.id)
- Replace post.render() with render(post) from astro:content
- Add null check for post.body in llms-full.txt.ts

Fixes CI check errors related to legacy content collections.